### PR TITLE
Feat: 영화 상세검색 api에 연령등급 추가

### DIFF
--- a/src/main/java/com/movie/test/common/api/tmdbAPI/dto/MovieCertificationDTO.java
+++ b/src/main/java/com/movie/test/common/api/tmdbAPI/dto/MovieCertificationDTO.java
@@ -1,0 +1,47 @@
+package com.movie.test.common.api.tmdbAPI.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MovieCertificationDTO {
+    private Integer id;
+    private List<CertificationResult> results;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CertificationResult {
+        private String iso_3166_1;
+        private List<ReleaseDateResult> release_dates;
+
+        public String getIso_3166_1() {
+            return iso_3166_1;
+        }
+
+        @Data
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class ReleaseDateResult {
+            private String certification;
+            private Object[] descriptors;
+            private String iso_639_1;
+            private String note;
+            private String release_date;
+            private String type;
+
+            public String getCertification() {
+                return certification;
+            }
+        }
+    }
+}

--- a/src/main/java/com/movie/test/common/api/tmdbAPI/dto/MovieDetailInfoDTO.java
+++ b/src/main/java/com/movie/test/common/api/tmdbAPI/dto/MovieDetailInfoDTO.java
@@ -37,5 +37,5 @@ public class MovieDetailInfoDTO {
     private Integer vote_count;
 
     private Object providers;
-
+    private String certification;
 }

--- a/src/main/java/com/movie/test/common/api/tmdbAPI/service/TmdbService.java
+++ b/src/main/java/com/movie/test/common/api/tmdbAPI/service/TmdbService.java
@@ -11,5 +11,5 @@ public interface TmdbService {
     Object getImages(MovieDetailSearchApiDTO movieSearchApiDTO);
     Object getConfiguration();
     Object getVideos(MovieDetailSearchApiDTO movieSearchApiDTO);
-
+    Object getCertification(String movieId);
 }


### PR DESCRIPTION
국가별로 하나의 영화에 대한 나이, 등급, 표현 방식이 달라 한국으로 1차 필터링
등급 정보가 없을 경우 미국 기준으로 필터링
미국도 없을 경우 No certification available 리턴
+ 미국이 아니더라도 한국을 제외한 첫 번째로 나오는 등급으로 변경될 수 있음